### PR TITLE
Bump jsoup from 1.13.1 to 1.14.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,7 +59,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 
     implementation("org.assertj:assertj-core:3.18.1")
-    implementation("org.jsoup:jsoup:1.13.1")
+    implementation("org.jsoup:jsoup:1.14.1")
 
     testImplementation("org.jetbrains.kotlin:kotlin-test")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit")

--- a/src/main/kotlin/io/github/ulfs/assertj/jsoup/Assertions.kt
+++ b/src/main/kotlin/io/github/ulfs/assertj/jsoup/Assertions.kt
@@ -12,11 +12,13 @@ public object Assertions {
     public fun assertThat(actual: Document?): DocumentAssert = DocumentAssert(actual)
 
     @JvmStatic
-    public fun assertThatDocument(actual: String?): DocumentAssert =
-        DocumentAssert(
-            Jsoup.parse(actual
-                .also { assertThat(actual).withFailMessage("%nExpecting document but found null").isNotNull })
-        )
+    public fun assertThatDocument(actual: String?): DocumentAssert {
+        assertThat(actual)
+            .withFailMessage("%nExpecting document but found null")
+            .isNotNull
+
+        return DocumentAssert(actual?.let { Jsoup.parse(it) })
+    }
 
     @JvmStatic
     public fun assertSoftly(assertions: Consumer<DocumentSoftAssertions>) {
@@ -56,10 +58,13 @@ public object Assertions {
         assert: DocumentAssertionsSpec.() -> DocumentAssertionsSpec
     ) {
         assertThat(actual)
-            .withFailMessage("%nExpecting document but found%n  null")
+            .withFailMessage("%nExpecting document but found null")
             .isNotNull
-        val document = Jsoup.parse(actual)
-        assertThatSpec(document, softly, assert)
+
+        actual?.let {
+            val document = Jsoup.parse(it)
+            assertThatSpec(document, softly, assert)
+        }
     }
 
     @JvmSynthetic

--- a/src/main/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssert.kt
+++ b/src/main/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssert.kt
@@ -14,7 +14,7 @@ public open class DocumentAssert(
         isNotNull
 
         val selection = actual.selectFirst(cssSelector)
-        if (selection == null) {
+        if (selection === null) {
             failWithElementNotFound(cssSelector)
         }
     }
@@ -45,7 +45,7 @@ public open class DocumentAssert(
         isNotNull
 
         val selection = actual.selectFirst(cssSelector)
-        if (selection != null) {
+        if (selection !== null) {
             failWithActualExpectedAndMessage(
                 selection,
                 null,
@@ -99,7 +99,7 @@ public open class DocumentAssert(
         isNotNull
 
         val selection = actual.selectFirst(cssSelector)
-        if (selection == null) {
+        if (selection === null) {
             failWithElementNotFound(cssSelector)
             return this
         }
@@ -181,7 +181,7 @@ public open class DocumentAssert(
         isNotNull
 
         val selection = actual.selectFirst(cssSelector)
-        if (selection == null) {
+        if (selection === null) {
             failWithElementNotFound(cssSelector)
             return this
         }
@@ -208,7 +208,7 @@ public open class DocumentAssert(
         isNotNull
 
         val selection = actual.selectFirst(cssSelector)
-        if (selection == null) {
+        if (selection === null) {
             failWithElementNotFound(cssSelector)
             return this
         }
@@ -390,7 +390,7 @@ public open class DocumentAssert(
         isNotNull
 
         val selection = actual.selectFirst(cssSelector)
-        if (selection == null) {
+        if (selection === null) {
             failWithElementNotFound(cssSelector)
             return this
         }
@@ -420,7 +420,7 @@ public open class DocumentAssert(
 
         val selection = actual.selectFirst(cssSelector)
 
-        if (selection == null) {
+        if (selection === null) {
             failWithElementNotFound(cssSelector)
             return this
         }

--- a/src/main/kotlin/io/github/ulfs/assertj/jsoup/DocumentSoftAssertions.kt
+++ b/src/main/kotlin/io/github/ulfs/assertj/jsoup/DocumentSoftAssertions.kt
@@ -12,5 +12,5 @@ public class DocumentSoftAssertions(
         if (softly) proxy(DocumentAssert::class.java, Document::class.java, actual)
         else DocumentAssert(actual)
 
-    public fun assertThatDocument(actual: String?): DocumentAssert = assertThat(Jsoup.parse(actual))
+    public fun assertThatDocument(actual: String?): DocumentAssert = assertThat(actual?.let { Jsoup.parse(it) })
 }


### PR DESCRIPTION
- fix nullability checks
- workaround using === checks (compiler bug?)
- align a failure message