### PR TITLE
Add HTML assertion methods

### DIFF
--- a/api/assertj-jsoup.api
+++ b/api/assertj-jsoup.api
@@ -78,6 +78,7 @@ public final class io/github/ulfs/assertj/jsoup/NodeAssertionsSpec {
 	public fun <init> (Lio/github/ulfs/assertj/jsoup/DocumentSoftAssertions;Lorg/jsoup/nodes/Document;Ljava/lang/String;)V
 	public final fun attribute (Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/NodeAssertionsSpec;
 	public final fun attribute (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Lio/github/ulfs/assertj/jsoup/NodeAssertionsSpec;
+	public final fun containsHtml (Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/NodeAssertionsSpec;
 	public final fun containsText (Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/NodeAssertionsSpec;
 	public final fun copy (Lio/github/ulfs/assertj/jsoup/DocumentSoftAssertions;Lorg/jsoup/nodes/Document;Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/NodeAssertionsSpec;
 	public static synthetic fun copy$default (Lio/github/ulfs/assertj/jsoup/NodeAssertionsSpec;Lio/github/ulfs/assertj/jsoup/DocumentSoftAssertions;Lorg/jsoup/nodes/Document;Ljava/lang/String;ILjava/lang/Object;)Lio/github/ulfs/assertj/jsoup/NodeAssertionsSpec;
@@ -86,6 +87,9 @@ public final class io/github/ulfs/assertj/jsoup/NodeAssertionsSpec {
 	public final fun exists (I)Lio/github/ulfs/assertj/jsoup/NodeAssertionsSpec;
 	public final fun hasAttribute (Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/NodeAssertionsSpec;
 	public final fun hasClass (Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/NodeAssertionsSpec;
+	public final fun hasHtml (Ljava/lang/Object;)Lio/github/ulfs/assertj/jsoup/NodeAssertionsSpec;
+	public final fun hasHtml (Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/NodeAssertionsSpec;
+	public final fun hasHtml ([Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/NodeAssertionsSpec;
 	public final fun hasText (Ljava/lang/Object;)Lio/github/ulfs/assertj/jsoup/NodeAssertionsSpec;
 	public final fun hasText (Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/NodeAssertionsSpec;
 	public final fun hasText ([Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/NodeAssertionsSpec;

--- a/api/assertj-jsoup.api
+++ b/api/assertj-jsoup.api
@@ -40,12 +40,16 @@ public class io/github/ulfs/assertj/jsoup/DocumentAssert : org/assertj/core/api/
 	public final fun elementAttributeHasText (Ljava/lang/String;Ljava/lang/String;[Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/DocumentAssert;
 	public final fun elementAttributeMatchesText (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/DocumentAssert;
 	public final fun elementAttributeNotExists (Ljava/lang/String;Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/DocumentAssert;
+	public final fun elementContainsHtml (Ljava/lang/String;Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/DocumentAssert;
 	public final fun elementContainsText (Ljava/lang/String;Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/DocumentAssert;
 	public final fun elementExists (Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/DocumentAssert;
 	public final fun elementExists (Ljava/lang/String;I)Lio/github/ulfs/assertj/jsoup/DocumentAssert;
 	public final fun elementHasClass (Ljava/lang/String;Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/DocumentAssert;
+	public final fun elementHasHtml (Ljava/lang/String;Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/DocumentAssert;
+	public final fun elementHasHtml (Ljava/lang/String;[Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/DocumentAssert;
 	public final fun elementHasText (Ljava/lang/String;Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/DocumentAssert;
 	public final fun elementHasText (Ljava/lang/String;[Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/DocumentAssert;
+	public final fun elementMatchesHtml (Ljava/lang/String;Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/DocumentAssert;
 	public final fun elementMatchesText (Ljava/lang/String;Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/DocumentAssert;
 	public final fun elementNotExists (Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/DocumentAssert;
 	public final fun elementNotHasClass (Ljava/lang/String;Ljava/lang/String;)Lio/github/ulfs/assertj/jsoup/DocumentAssert;

--- a/src/main/kotlin/io/github/ulfs/assertj/jsoup/Assertions.kt
+++ b/src/main/kotlin/io/github/ulfs/assertj/jsoup/Assertions.kt
@@ -2,7 +2,6 @@ package io.github.ulfs.assertj.jsoup
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.SoftAssertionsProvider
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import java.util.function.Consumer
 
@@ -17,7 +16,7 @@ public object Assertions {
             .withFailMessage("%nExpecting document but found null")
             .isNotNull
 
-        return DocumentAssert(Jsoup.parse(actual!!))
+        return DocumentAssert(JsoupUtils.parse(actual!!))
     }
 
     @JvmStatic
@@ -62,7 +61,7 @@ public object Assertions {
             .isNotNull
 
         actual?.let {
-            val document = Jsoup.parse(it)
+            val document = JsoupUtils.parse(it)
             assertThatSpec(document, softly, assert)
         }
     }

--- a/src/main/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssert.kt
+++ b/src/main/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssert.kt
@@ -6,6 +6,7 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import org.jsoup.select.Elements
 
+@Suppress("detekt:LargeClass", "detekt:TooManyFunctions")
 public open class DocumentAssert(
     actual: Document?
 ) : AbstractAssert<DocumentAssert, Document>(actual, DocumentAssert::class.java) {
@@ -91,6 +92,142 @@ public open class DocumentAssert(
                 attribute,
                 cssSelector,
                 selection
+            )
+        }
+    }
+
+    public fun elementHasHtml(cssSelector: String, string: String): DocumentAssert = apply {
+        isNotNull
+
+        val selection = actual.selectFirst(cssSelector)
+        if (selection === null) {
+            failWithElementNotFound(cssSelector)
+            return this
+        }
+
+        val html = selection.html()
+        if (html != string) {
+            failWithActualExpectedAndMessage(
+                html,
+                string,
+                "%nExpecting element for%n" +
+                        "  <%s>%n" +
+                        "to have html%n" +
+                        "  <%s>%n" +
+                        "but was%n" +
+                        "  <%s>",
+                cssSelector,
+                string,
+                html
+            )
+        }
+    }
+
+    public fun elementHasHtml(cssSelector: String, vararg strings: String): DocumentAssert = apply {
+        isNotNull
+
+        if (strings.isEmpty()) {
+            throw IllegalArgumentException("elementHasHtml expects at least two arguments")
+        }
+
+        val selection = actual.select(cssSelector)
+        if (selection.isEmpty()) {
+            failWithElementNotFound(cssSelector)
+            return this
+        }
+
+        strings.zip(selection).onEachIndexed { index, matchPair ->
+            val elementHtml = matchPair.second.html()
+            val expectedHtml = matchPair.first
+            if (elementHtml != expectedHtml) {
+                failWithActualExpectedAndMessage(
+                    elementHtml,
+                    expectedHtml,
+                    "%nExpecting element at position" +
+                            " %s " +
+                            "in list for%n" +
+                            "  <%s>%n" +
+                            "to have html%n" +
+                            "  <%s>%n" +
+                            "but was%n" +
+                            "  <%s>",
+                    index,
+                    cssSelector,
+                    expectedHtml,
+                    elementHtml
+                )
+                return this
+            }
+        }
+
+        if (selection.size < strings.size) {
+            val rest = strings.drop(selection.size)
+            failWithMessage(
+                "%nExpecting" +
+                        " %s more element(s) for%n" +
+                        "  %s%n" +
+                        "to be html%n" +
+                        "%s%n" +
+                        "in list%n" +
+                        "%s",
+                rest.size,
+                cssSelector,
+                maskSelection(rest),
+                maskSelection(selection)
+            )
+        }
+    }
+
+    public fun elementContainsHtml(cssSelector: String, substring: String): DocumentAssert = apply {
+        isNotNull
+
+        val selection = actual.selectFirst(cssSelector)
+        if (selection === null) {
+            failWithElementNotFound(cssSelector)
+            return this
+        }
+
+        val html = selection.html()
+        if (!html.contains(substring)) {
+            failWithActualExpectedAndMessage(
+                html,
+                substring,
+                "%nExpecting element for%n" +
+                        "  <%s>%n" +
+                        "to contain html%n" +
+                        "  <%s>%n" +
+                        "but was%n" +
+                        "  <%s>",
+                cssSelector,
+                substring,
+                html
+            )
+        }
+    }
+
+    public fun elementMatchesHtml(cssSelector: String, regex: String): DocumentAssert = apply {
+        isNotNull
+
+        val selection = actual.selectFirst(cssSelector)
+        if (selection === null) {
+            failWithElementNotFound(cssSelector)
+            return this
+        }
+
+        val html = selection.html()
+        if (!html.contains(regex.toRegex())) {
+            failWithActualExpectedAndMessage(
+                html,
+                regex,
+                "%nExpecting element for%n" +
+                        "  <%s>%n" +
+                        "to match regex for html%n" +
+                        "  <%s>%n" +
+                        "but was%n" +
+                        "  <%s>",
+                cssSelector,
+                regex,
+                html
             )
         }
     }

--- a/src/main/kotlin/io/github/ulfs/assertj/jsoup/DocumentSoftAssertions.kt
+++ b/src/main/kotlin/io/github/ulfs/assertj/jsoup/DocumentSoftAssertions.kt
@@ -1,7 +1,6 @@
 package io.github.ulfs.assertj.jsoup
 
 import org.assertj.core.api.SoftAssertions
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 
 public class DocumentSoftAssertions(
@@ -12,5 +11,5 @@ public class DocumentSoftAssertions(
         if (softly) proxy(DocumentAssert::class.java, Document::class.java, actual)
         else DocumentAssert(actual)
 
-    public fun assertThatDocument(actual: String?): DocumentAssert = assertThat(actual?.let { Jsoup.parse(it) })
+    public fun assertThatDocument(actual: String?): DocumentAssert = assertThat(actual?.let { JsoupUtils.parse(it) })
 }

--- a/src/main/kotlin/io/github/ulfs/assertj/jsoup/JsoupUtils.kt
+++ b/src/main/kotlin/io/github/ulfs/assertj/jsoup/JsoupUtils.kt
@@ -1,0 +1,10 @@
+package io.github.ulfs.assertj.jsoup
+
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+
+internal object JsoupUtils {
+
+    internal fun parse(string: String): Document = Jsoup.parse(string)
+
+}

--- a/src/main/kotlin/io/github/ulfs/assertj/jsoup/NodeAssertionsSpec.kt
+++ b/src/main/kotlin/io/github/ulfs/assertj/jsoup/NodeAssertionsSpec.kt
@@ -20,6 +20,22 @@ public data class NodeAssertionsSpec(
         softAssertions.assertThat(document).elementNotExists(cssSelector)
     }
 
+    public fun containsHtml(substring: String): NodeAssertionsSpec = apply {
+        softAssertions.assertThat(document).elementContainsHtml(cssSelector, substring)
+    }
+
+    public fun hasHtml(text: String): NodeAssertionsSpec = apply {
+        softAssertions.assertThat(document).elementHasHtml(cssSelector, text)
+    }
+
+    public fun hasHtml(vararg texts: String): NodeAssertionsSpec = apply {
+        softAssertions.assertThat(document).elementHasHtml(cssSelector, *texts)
+    }
+
+    public fun hasHtml(obj: Any?): NodeAssertionsSpec = apply {
+        softAssertions.assertThat(document).elementHasHtml(cssSelector, obj?.toString() ?: "")
+    }
+
     public fun containsText(substring: String): NodeAssertionsSpec = apply {
         softAssertions.assertThat(document).elementContainsText(cssSelector, substring)
     }

--- a/src/test/kotlin/io/github/ulfs/assertj/jsoup/AssertionsTest.kt
+++ b/src/test/kotlin/io/github/ulfs/assertj/jsoup/AssertionsTest.kt
@@ -52,8 +52,13 @@ class AssertionsTest {
         // given
         val document: Document = mockk()
         val element: Element = mockk()
+        val outputSettings: Document.OutputSettings = mockk {
+            every { prettyPrint(any()) } returns this
+        }
         every { Jsoup.parse(any<String>()) } returns document
+        every { document.outputSettings() } returns outputSettings
         every { document.selectFirst(any<String>()) } returns element
+
 
         // when
         val documentAssert = Assertions.assertThatDocument("html")
@@ -219,7 +224,7 @@ class AssertionsTest {
         var documentAssert: DocumentAssertionsSpec? = null
 
         // when
-        Assertions.assertThatSpec(Jsoup.parse("html")) {
+        Assertions.assertThatSpec(JsoupUtils.parse("html")) {
             documentAssert = this
             this
         }

--- a/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementAttributeContainsTextTest.kt
+++ b/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementAttributeContainsTextTest.kt
@@ -5,7 +5,6 @@ import io.github.ulfs.assertj.jsoup.test.hasErrorWithMessage
 import io.github.ulfs.assertj.jsoup.test.hasOneError
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.util.FailureMessages.actualIsNull
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import kotlin.test.Test
 
@@ -27,7 +26,7 @@ class DocumentAssertElementAttributeContainsTextTest {
     @Test
     fun `should fail if element does not exist`() {
         // given
-        val document: Document = Jsoup.parse("")
+        val document: Document = JsoupUtils.parse("")
 
         // when / then
         assertThatThrownBy {
@@ -50,7 +49,7 @@ class DocumentAssertElementAttributeContainsTextTest {
     @Test
     fun `should pass if element has entire attribute value`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class" attr="value"></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class" attr="value"></div>""")
 
         // when
         assertThat(document, true) {
@@ -64,7 +63,7 @@ class DocumentAssertElementAttributeContainsTextTest {
     @Test
     fun `should fail if element has attribute in inner node`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"><span attr="value"></span></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"><span attr="value"></span></div>""")
 
         // when / then
         assertThatThrownBy {
@@ -92,7 +91,7 @@ class DocumentAssertElementAttributeContainsTextTest {
     @Test
     fun `should pass if searched value is substring of attribute value`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class" attr="value"></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class" attr="value"></div>""")
 
         // when / then
         assertThat(document, true) {
@@ -106,7 +105,7 @@ class DocumentAssertElementAttributeContainsTextTest {
     @Test
     fun `should fail if attribute contains different value`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class" attr="different"></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class" attr="different"></div>""")
 
         // when / then
         assertThatThrownBy {
@@ -134,7 +133,7 @@ class DocumentAssertElementAttributeContainsTextTest {
     @Test
     fun `should fail if attribute is missing on element`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"></div>""")
 
         // when / then
         assertThatThrownBy {

--- a/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementAttributeExistsTest.kt
+++ b/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementAttributeExistsTest.kt
@@ -5,7 +5,6 @@ import io.github.ulfs.assertj.jsoup.test.hasErrorWithMessage
 import io.github.ulfs.assertj.jsoup.test.hasOneError
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.util.FailureMessages.actualIsNull
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import kotlin.test.Test
 
@@ -27,7 +26,7 @@ class DocumentAssertElementAttributeExistsTest {
     @Test
     fun `should fail if element does not exist`() {
         // given
-        val document: Document = Jsoup.parse("")
+        val document: Document = JsoupUtils.parse("")
 
         // when / then
         assertThatThrownBy {
@@ -50,7 +49,7 @@ class DocumentAssertElementAttributeExistsTest {
     @Test
     fun `should fail if element exists without attribute`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"/>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"/>""")
 
         // when / then
         assertThatThrownBy {
@@ -76,7 +75,7 @@ class DocumentAssertElementAttributeExistsTest {
     @Test
     fun `should pass if element with attribute exists`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class" attr/>""")
+        val document: Document = JsoupUtils.parse("""<div class="class" attr/>""")
 
         // when
         assertThat(document, true) {

--- a/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementAttributeHasTextTest.kt
+++ b/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementAttributeHasTextTest.kt
@@ -5,7 +5,6 @@ import io.github.ulfs.assertj.jsoup.test.hasErrorWithMessage
 import io.github.ulfs.assertj.jsoup.test.hasOneError
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.util.FailureMessages.actualIsNull
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import kotlin.test.Test
 
@@ -27,7 +26,7 @@ class DocumentAssertElementAttributeHasTextTest {
     @Test
     fun `should fail if element does not exist`() {
         // given
-        val document: Document = Jsoup.parse("")
+        val document: Document = JsoupUtils.parse("")
 
         // when / then
         assertThatThrownBy {
@@ -50,7 +49,7 @@ class DocumentAssertElementAttributeHasTextTest {
     @Test
     fun `should throw if insufficient parameters are given`() {
         // given
-        val document: Document = Jsoup.parse("")
+        val document: Document = JsoupUtils.parse("")
 
         // when / then
         assertThatThrownBy {
@@ -64,7 +63,7 @@ class DocumentAssertElementAttributeHasTextTest {
     @Test
     fun `should fail if element does not exist for multiple strings`() {
         // given
-        val document: Document = Jsoup.parse("")
+        val document: Document = JsoupUtils.parse("")
 
         // when / then
         assertThatThrownBy {
@@ -87,7 +86,7 @@ class DocumentAssertElementAttributeHasTextTest {
     @Test
     fun `should pass if element has attribute value`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class" attr="value"></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class" attr="value"></div>""")
 
         // when
         assertThat(document, true) {
@@ -101,7 +100,7 @@ class DocumentAssertElementAttributeHasTextTest {
     @Test
     fun `should fail if element has attribute in inner node`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"><span attr="value"></span></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"><span attr="value"></span></div>""")
 
         // when / then
         assertThatThrownBy {
@@ -133,7 +132,7 @@ class DocumentAssertElementAttributeHasTextTest {
     @Test
     fun `should fail if searched value is substring of attribute value`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class" attr="value"></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class" attr="value"></div>""")
 
         // when / then
         assertThatThrownBy {
@@ -161,7 +160,7 @@ class DocumentAssertElementAttributeHasTextTest {
     @Test
     fun `should fail if attribute contains different value`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class" attr="different"></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class" attr="different"></div>""")
 
         // when / then
         assertThatThrownBy {
@@ -189,7 +188,7 @@ class DocumentAssertElementAttributeHasTextTest {
     @Test
     fun `should fail if attribute is missing on element`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"></div>""")
 
         // when / then
         assertThatThrownBy {
@@ -215,7 +214,7 @@ class DocumentAssertElementAttributeHasTextTest {
     @Test
     fun `should pass if elements have corresponding attributes`() {
         // given
-        val document: Document = Jsoup.parse(
+        val document: Document = JsoupUtils.parse(
             """
             <div class="class" attr="this"></div>
             <div class="class" attr="is"></div>
@@ -235,7 +234,7 @@ class DocumentAssertElementAttributeHasTextTest {
     @Test
     fun `should fail if elements do not have matching attributes`() {
         // given
-        val document: Document = Jsoup.parse(
+        val document: Document = JsoupUtils.parse(
             """
             <div class="class" attr="this"></div>
             <div class="class" attr="is not"></div>
@@ -271,7 +270,7 @@ class DocumentAssertElementAttributeHasTextTest {
     @Test
     fun `should fail if elements are missing one element with attribute`() {
         // given
-        val document: Document = Jsoup.parse(
+        val document: Document = JsoupUtils.parse(
             """
             <div class="class" attr="this"></div>
             <div class="class" attr="is"></div>
@@ -303,7 +302,7 @@ class DocumentAssertElementAttributeHasTextTest {
     @Test
     fun `should pass if elements have more elements with attribute than given`() {
         // given
-        val document: Document = Jsoup.parse(
+        val document: Document = JsoupUtils.parse(
             """
             <div class="class" attr="this"></div>
             <div class="class" attr="is"></div>

--- a/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementAttributeMatchesTextTest.kt
+++ b/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementAttributeMatchesTextTest.kt
@@ -5,7 +5,6 @@ import io.github.ulfs.assertj.jsoup.test.hasErrorWithMessage
 import io.github.ulfs.assertj.jsoup.test.hasOneError
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.util.FailureMessages.actualIsNull
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import kotlin.test.Test
 
@@ -27,7 +26,7 @@ class DocumentAssertElementAttributeMatchesTextTest {
     @Test
     fun `should fail if element does not exist`() {
         // given
-        val document: Document = Jsoup.parse("")
+        val document: Document = JsoupUtils.parse("")
 
         // when / then
         assertThatThrownBy {
@@ -50,7 +49,7 @@ class DocumentAssertElementAttributeMatchesTextTest {
     @Test
     fun `should pass if element matches`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class" attr="value"></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class" attr="value"></div>""")
 
         // when
         assertThat(document, true) {
@@ -64,7 +63,7 @@ class DocumentAssertElementAttributeMatchesTextTest {
     @Test
     fun `should fail if element has attribute in inner node`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"><span attr="value"></span></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"><span attr="value"></span></div>""")
 
         // when / then
         assertThatThrownBy {
@@ -92,7 +91,7 @@ class DocumentAssertElementAttributeMatchesTextTest {
     @Test
     fun `should fail if attribute does not match`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class" attr="different"></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class" attr="different"></div>""")
 
         // when / then
         assertThatThrownBy {
@@ -120,7 +119,7 @@ class DocumentAssertElementAttributeMatchesTextTest {
     @Test
     fun `should fail if attribute is missing on element`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"></div>""")
 
         // when / then
         assertThatThrownBy {

--- a/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementAttributeNotExistsTest.kt
+++ b/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementAttributeNotExistsTest.kt
@@ -5,7 +5,6 @@ import io.github.ulfs.assertj.jsoup.test.hasErrorWithMessage
 import io.github.ulfs.assertj.jsoup.test.hasOneError
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.util.FailureMessages.actualIsNull
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import kotlin.test.Test
 
@@ -27,7 +26,7 @@ class DocumentAssertElementAttributeNotExistsTest {
     @Test
     fun `should fail if element does not exist`() {
         // given
-        val document: Document = Jsoup.parse("")
+        val document: Document = JsoupUtils.parse("")
 
         // when / then
         assertThatThrownBy {
@@ -50,7 +49,7 @@ class DocumentAssertElementAttributeNotExistsTest {
     @Test
     fun `should pass if element exists without attribute`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"/>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"/>""")
 
         // when
         assertThat(document, true) {
@@ -64,7 +63,7 @@ class DocumentAssertElementAttributeNotExistsTest {
     @Test
     fun `should fail if element with attribute exists`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class" attr/>""")
+        val document: Document = JsoupUtils.parse("""<div class="class" attr/>""")
 
         // when / then
         assertThatThrownBy {

--- a/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementContainsHtmlTest.kt
+++ b/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementContainsHtmlTest.kt
@@ -5,7 +5,6 @@ import io.github.ulfs.assertj.jsoup.test.hasErrorWithMessage
 import io.github.ulfs.assertj.jsoup.test.hasOneError
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.util.FailureMessages.actualIsNull
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import kotlin.test.Test
 
@@ -27,7 +26,7 @@ class DocumentAssertElementContainsHtmlTest {
     @Test
     fun `should fail if element does not exist`() {
         // given
-        val document: Document = Jsoup.parse("")
+        val document: Document = JsoupUtils.parse("")
 
         // when / then
         assertThatThrownBy {
@@ -50,7 +49,7 @@ class DocumentAssertElementContainsHtmlTest {
     @Test
     fun `should pass if element contains html`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class">html<br>text</div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class">html<br>text</div>""")
 
         // when
         assertThat(document, true) {
@@ -64,7 +63,7 @@ class DocumentAssertElementContainsHtmlTest {
     @Test
     fun `should pass if element contains html in different form`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class">html<br/>text</div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class">html<br/>text</div>""")
 
         // when
         assertThat(document, true) {
@@ -78,7 +77,7 @@ class DocumentAssertElementContainsHtmlTest {
     @Test
     fun `should pass if element contains nested html`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"><p><span>text</span><span>html</span></p></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"><p><span>text</span><span>html</span></p></div>""")
 
         // when
         assertThat(document, true) {
@@ -92,7 +91,7 @@ class DocumentAssertElementContainsHtmlTest {
     @Test
     fun `should pass if element contains complex html`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"><span><b>h</b>t<strong>m</strong>l</span></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"><span><b>h</b>t<strong>m</strong>l</span></div>""")
 
         // when
         assertThat(document, true) {
@@ -106,7 +105,7 @@ class DocumentAssertElementContainsHtmlTest {
     @Test
     fun `should pass if element text is the entire html`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class">html<br>text</div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class">html<br>text</div>""")
 
         // when / then
         assertThat(document, true) {
@@ -120,7 +119,7 @@ class DocumentAssertElementContainsHtmlTest {
     @Test
     fun `should fail if element does not contain the html`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class">different<img>html</div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class">different<img>html</div>""")
 
         // when / then
         assertThatThrownBy {

--- a/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementContainsHtmlTest.kt
+++ b/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementContainsHtmlTest.kt
@@ -1,0 +1,145 @@
+package io.github.ulfs.assertj.jsoup
+
+import io.github.ulfs.assertj.jsoup.Assertions.assertThat
+import io.github.ulfs.assertj.jsoup.test.hasErrorWithMessage
+import io.github.ulfs.assertj.jsoup.test.hasOneError
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.core.util.FailureMessages.actualIsNull
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import kotlin.test.Test
+
+class DocumentAssertElementContainsHtmlTest {
+
+    @Test
+    fun `should fail if element is null`() {
+        // given
+        val nullDocument: Document? = null
+
+        // when / then
+        assertThatThrownBy {
+            assertThat(nullDocument).elementContainsHtml(".class", "<br>")
+        }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(actualIsNull())
+    }
+
+    @Test
+    fun `should fail if element does not exist`() {
+        // given
+        val document: Document = Jsoup.parse("")
+
+        // when / then
+        assertThatThrownBy {
+            assertThat(document, true) {
+                elementContainsHtml(".class", "<br>")
+            }
+        }
+            .isInstanceOf(AssertionError::class.java)
+            .hasOneError()
+            .hasErrorWithMessage(
+                """
+                
+                Expecting element for
+                  <.class>
+                but found nothing
+                """.trimIndent()
+            )
+    }
+
+    @Test
+    fun `should pass if element contains html`() {
+        // given
+        val document: Document = Jsoup.parse("""<div class="class">html<br>text</div>""")
+
+        // when
+        assertThat(document, true) {
+            elementContainsHtml(".class", """ml<br>te""")
+        }
+
+        // then
+        // no exception is thrown
+    }
+
+    @Test
+    fun `should pass if element contains html in different form`() {
+        // given
+        val document: Document = Jsoup.parse("""<div class="class">html<br/>text</div>""")
+
+        // when
+        assertThat(document, true) {
+            elementContainsHtml(".class", """ml<br>te""")
+        }
+
+        // then
+        // no exception is thrown
+    }
+
+    @Test
+    fun `should pass if element contains nested html`() {
+        // given
+        val document: Document = Jsoup.parse("""<div class="class"><p><span>text</span><span>html</span></p></div>""")
+
+        // when
+        assertThat(document, true) {
+            elementContainsHtml(".class", "<span>html</span>")
+        }
+
+        // then
+        // no exception is thrown
+    }
+
+    @Test
+    fun `should pass if element contains complex html`() {
+        // given
+        val document: Document = Jsoup.parse("""<div class="class"><span><b>h</b>t<strong>m</strong>l</span></div>""")
+
+        // when
+        assertThat(document, true) {
+            elementContainsHtml(".class", "<b>h</b>t<strong>m</strong>l")
+        }
+
+        // then
+        // no exception is thrown
+    }
+
+    @Test
+    fun `should pass if element text is the entire html`() {
+        // given
+        val document: Document = Jsoup.parse("""<div class="class">html<br>text</div>""")
+
+        // when / then
+        assertThat(document, true) {
+            elementContainsHtml(".class", "html<br>text")
+        }
+
+        // then
+        // no exception is thrown
+    }
+
+    @Test
+    fun `should fail if element does not contain the html`() {
+        // given
+        val document: Document = Jsoup.parse("""<div class="class">different<img>html</div>""")
+
+        // when / then
+        assertThatThrownBy {
+            assertThat(document, true) {
+                elementContainsHtml(".class", "text")
+            }
+        }
+            .isInstanceOf(AssertionError::class.java)
+            .hasOneError()
+            .hasErrorWithMessage(
+                """
+                
+                Expecting element for
+                  <.class>
+                to contain html
+                  <text>
+                but was
+                  <different<img>html>
+                """.trimIndent()
+            )
+    }
+}

--- a/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementContainsTextTest.kt
+++ b/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementContainsTextTest.kt
@@ -5,7 +5,6 @@ import io.github.ulfs.assertj.jsoup.test.hasErrorWithMessage
 import io.github.ulfs.assertj.jsoup.test.hasOneError
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.util.FailureMessages.actualIsNull
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import kotlin.test.Test
 
@@ -27,7 +26,7 @@ class DocumentAssertElementContainsTextTest {
     @Test
     fun `should fail if element does not exist`() {
         // given
-        val document: Document = Jsoup.parse("")
+        val document: Document = JsoupUtils.parse("")
 
         // when / then
         assertThatThrownBy {
@@ -50,7 +49,7 @@ class DocumentAssertElementContainsTextTest {
     @Test
     fun `should pass if element contains text`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class">text</div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class">text</div>""")
 
         // when
         assertThat(document, true) {
@@ -64,7 +63,7 @@ class DocumentAssertElementContainsTextTest {
     @Test
     fun `should pass if element contains text in inner node`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"><span>text</span></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"><span>text</span></div>""")
 
         // when
         assertThat(document, true) {
@@ -78,7 +77,7 @@ class DocumentAssertElementContainsTextTest {
     @Test
     fun `should pass if element contains text in inner nodes`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"><span><b>t</b>e<strong>x</strong>t</span></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"><span><b>t</b>e<strong>x</strong>t</span></div>""")
 
         // when
         assertThat(document, true) {
@@ -92,7 +91,7 @@ class DocumentAssertElementContainsTextTest {
     @Test
     fun `should pass if element text is the entire text`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class">text</div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class">text</div>""")
 
         // when / then
         assertThat(document, true) {
@@ -106,7 +105,7 @@ class DocumentAssertElementContainsTextTest {
     @Test
     fun `should fail if element does not contain the text`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class">different</div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class">different</div>""")
 
         // when / then
         assertThatThrownBy {

--- a/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementExistsTest.kt
+++ b/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementExistsTest.kt
@@ -5,7 +5,6 @@ import io.github.ulfs.assertj.jsoup.test.hasErrorWithMessage
 import io.github.ulfs.assertj.jsoup.test.hasOneError
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.util.FailureMessages.actualIsNull
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import kotlin.test.Test
 
@@ -27,7 +26,7 @@ class DocumentAssertElementExistsTest {
     @Test
     fun `should fail if element does not exist`() {
         // given
-        val document: Document = Jsoup.parse("")
+        val document: Document = JsoupUtils.parse("")
 
         // when / then
         assertThatThrownBy {
@@ -50,7 +49,7 @@ class DocumentAssertElementExistsTest {
     @Test
     fun `should pass if element exists`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"/>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"/>""")
 
         // when
         assertThat(document, true) {
@@ -64,7 +63,7 @@ class DocumentAssertElementExistsTest {
     @Test
     fun `should pass if element exists more than once`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"/><div class="class"/>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"/><div class="class"/>""")
 
         // when
         assertThat(document, true) {
@@ -78,7 +77,7 @@ class DocumentAssertElementExistsTest {
     @Test
     fun `should fail if element exists less than twice`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"/>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"/>""")
 
         // when / then
         assertThatThrownBy {
@@ -106,7 +105,7 @@ class DocumentAssertElementExistsTest {
     @Test
     fun `should fail if element exists more than twice`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"/><div class="class"/><div class="class"/>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"/><div class="class"/><div class="class"/>""")
 
         // when / then
         assertThatThrownBy {
@@ -136,7 +135,7 @@ class DocumentAssertElementExistsTest {
     @Test
     fun `should pass if element exists exactly twice`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"/><div class="class"/>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"/><div class="class"/>""")
 
         // when
         assertThat(document, true) {

--- a/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementHasClassTest.kt
+++ b/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementHasClassTest.kt
@@ -5,7 +5,6 @@ import io.github.ulfs.assertj.jsoup.test.hasErrorWithMessage
 import io.github.ulfs.assertj.jsoup.test.hasOneError
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.util.FailureMessages.actualIsNull
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import kotlin.test.Test
 
@@ -27,7 +26,7 @@ class DocumentAssertElementHasClassTest {
     @Test
     fun `should fail if element does not exist`() {
         // given
-        val document: Document = Jsoup.parse("")
+        val document: Document = JsoupUtils.parse("")
 
         // when / then
         assertThatThrownBy {
@@ -50,7 +49,7 @@ class DocumentAssertElementHasClassTest {
     @Test
     fun `should fail if element does not have class attribute`() {
         // given
-        val document: Document = Jsoup.parse("""<div id="id">""")
+        val document: Document = JsoupUtils.parse("""<div id="id">""")
 
         // when / then
         assertThatThrownBy {
@@ -76,7 +75,7 @@ class DocumentAssertElementHasClassTest {
     @Test
     fun `should pass if element has class`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class content">text</div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class content">text</div>""")
 
         // when
         assertThat(document, true) {
@@ -90,7 +89,7 @@ class DocumentAssertElementHasClassTest {
     @Test
     fun `should fail if only inner element has class`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"><span class="content">text</span></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"><span class="content">text</span></div>""")
 
         // when / then
         assertThatThrownBy {
@@ -118,7 +117,7 @@ class DocumentAssertElementHasClassTest {
     @Test
     fun `should fail if element does not have class`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class cont">text</div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class cont">text</div>""")
 
         // when / then
         assertThatThrownBy {

--- a/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementHasHtmlTest.kt
+++ b/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementHasHtmlTest.kt
@@ -1,0 +1,290 @@
+package io.github.ulfs.assertj.jsoup
+
+import io.github.ulfs.assertj.jsoup.Assertions.assertThat
+import io.github.ulfs.assertj.jsoup.test.hasErrorWithMessage
+import io.github.ulfs.assertj.jsoup.test.hasOneError
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.core.error.AssertJMultipleFailuresError
+import org.assertj.core.util.FailureMessages.actualIsNull
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import kotlin.test.Test
+
+class DocumentAssertElementHasHtmlTest {
+
+    @Test
+    fun `should fail if element is null`() {
+        // given
+        val nullDocument: Document? = null
+
+        // when / then
+        assertThatThrownBy {
+            assertThat(nullDocument).elementHasHtml(".class", "<br>")
+        }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(actualIsNull())
+    }
+
+    @Test
+    fun `should fail if element does not exist`() {
+        // given
+        val document = Jsoup.parse("")
+
+        // when / then
+        assertThatThrownBy {
+            assertThat(document, true) {
+                elementHasHtml(".class", "<br>")
+            }
+        }
+            .isInstanceOf(AssertJMultipleFailuresError::class.java)
+            .hasOneError()
+            .hasErrorWithMessage(
+                """
+                
+                Expecting element for
+                  <.class>
+                but found nothing
+                """.trimIndent()
+            )
+    }
+
+    @Test
+    fun `should throw if insufficient parameters are given`() {
+        // given
+        val document: Document = Jsoup.parse("")
+
+        // when / then
+        assertThatThrownBy {
+            assertThat(document, true) {
+                elementHasHtml(".class")
+            }
+        }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `should fail if element does not exist for multiple strings`() {
+        // given
+        val document: Document = Jsoup.parse("")
+
+        // when / then
+        assertThatThrownBy {
+            assertThat(document, true) {
+                elementHasHtml(".class", "<br>", "<br>")
+            }
+        }
+            .isInstanceOf(AssertionError::class.java)
+            .hasOneError()
+            .hasErrorWithMessage(
+                """
+                
+                Expecting element for
+                  <.class>
+                but found nothing
+                """.trimIndent()
+            )
+    }
+
+    @Test
+    fun `should pass if element has html`() {
+        // given
+        val document: Document = Jsoup.parse("""<div class="class">text<br>html</div>""")
+
+        // when
+        assertThat(document, true) {
+            elementHasHtml(".class", "text<br>html")
+        }
+
+        // then
+        // no exception is thrown
+    }
+
+    @Test
+    fun `should pass if element has html in inner node`() {
+        // given
+        val document: Document = Jsoup.parse("""<div class="class"><span>text<br>html</span></div>""")
+
+        // when
+        assertThat(document, true) {
+            elementHasHtml(".class", "<span>text<br>html</span>")
+        }
+
+        // then
+        // no exception is thrown
+    }
+
+    @Test
+    fun `should pass if element has html in inner nodes`() {
+        // given
+        val document: Document = Jsoup.parse("""<div class="class"><span><b>h</b>t<strong>m</strong>l</span></div>""")
+
+        // when
+        assertThat(document, true) {
+            elementHasHtml(".class", "<span><b>h</b>t<strong>m</strong>l</span>")
+        }
+
+        // then
+        // no exception is thrown
+    }
+
+    @Test
+    fun `should fail if element contains substring`() {
+        // given
+        val document: Document = Jsoup.parse("""<div class="class">text<br>html</div>""")
+
+        // when / then
+        assertThatThrownBy {
+            assertThat(document, true) {
+                elementHasHtml(".class", "<br>")
+            }
+        }
+            .isInstanceOf(AssertionError::class.java)
+            .hasOneError()
+            .hasErrorWithMessage(
+                """
+                
+                Expecting element for
+                  <.class>
+                to have html
+                  <<br>>
+                but was
+                  <text<br>html>
+                """.trimIndent()
+            )
+    }
+
+    @Test
+    fun `should fail if element contains different html`() {
+        // given
+        val document: Document = Jsoup.parse("""<div class="class">different<br>html</div>""")
+
+        // when / then
+        assertThatThrownBy {
+            assertThat(document, true) {
+                elementHasHtml(".class", "text<br>html")
+            }
+        }
+            .isInstanceOf(AssertionError::class.java)
+            .hasOneError()
+            .hasErrorWithMessage(
+                """
+                
+                Expecting element for
+                  <.class>
+                to have html
+                  <text<br>html>
+                but was
+                  <different<br>html>
+                """.trimIndent()
+            )
+    }
+
+    @Test
+    fun `should pass if elements have corresponding html`() {
+        // given
+        val document: Document = Jsoup.parse(
+            """
+            <div class="class">this<br>is</div>
+            <div class="class">really<br>long</div>
+            <div class="class">html<br>text</div>
+            """.trimIndent()
+        )
+
+        // when
+        assertThat(document, true) {
+            elementHasHtml(".class", "this<br>is", "really<br>long", "html<br>text")
+        }
+
+        // then
+        // no exception is thrown
+    }
+
+    @Test
+    fun `should fail if elements dont have matching html`() {
+        // given
+        val document: Document = Jsoup.parse(
+            """
+            <div class="class">this<br>is</div>
+            <div class="class">really<br>wrong</div>
+            <div class="class">html<br>text</div>
+            """.trimIndent()
+        )
+
+        // when / then
+        assertThatThrownBy {
+            assertThat(document, true) {
+                elementHasHtml(".class", "this<br>is", "really<br>long", "html<br>text")
+            }
+        }
+            .isInstanceOf(AssertionError::class.java)
+            .hasOneError()
+            .hasErrorWithMessage(
+                """
+                
+                Expecting element at position 1 in list for
+                  <.class>
+                to have html
+                  <really<br>long>
+                but was
+                  <really<br>wrong>
+                """.trimIndent()
+            )
+    }
+
+    @Test
+    fun `should fail if elements are missing one element`() {
+        // given
+        val document: Document = Jsoup.parse(
+            """
+            <div class="class">this<br>is</div>
+            <div class="class">really<br>long</div>
+            """.trimIndent()
+        )
+
+        // when / then
+        assertThatThrownBy {
+            assertThat(document, true) {
+                elementHasHtml(".class", "this<br>is", "really<br>long", "html<br>text")
+            }
+        }
+            .isInstanceOf(AssertionError::class.java)
+            .hasOneError()
+            .hasErrorWithMessage(
+                """
+                
+                Expecting 1 more element(s) for
+                  .class
+                to be html
+                  [html<br>text]
+                in list
+                  <div class="class">
+                   this<br>is
+                  </div>
+                  <div class="class">
+                   really<br>long
+                  </div>
+                """.trimIndent()
+            )
+    }
+
+    @Test
+    fun `should pass if elements have more elements than given`() {
+        // given
+        val document: Document = Jsoup.parse(
+            """
+            <div class="class">this<br>is</div>
+            <div class="class">really<br>long</div>
+            <div class="class">html<br>text</div>
+            <div class="class">but<br>more</div>
+            """.trimIndent()
+        )
+
+        // when / then
+        assertThat(document, true) {
+            elementHasHtml(".class", "this<br>is", "really<br>long", "html<br>text")
+        }
+
+        // then
+        // no exception is thrown
+    }
+}

--- a/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementHasHtmlTest.kt
+++ b/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementHasHtmlTest.kt
@@ -6,7 +6,6 @@ import io.github.ulfs.assertj.jsoup.test.hasOneError
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.error.AssertJMultipleFailuresError
 import org.assertj.core.util.FailureMessages.actualIsNull
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import kotlin.test.Test
 
@@ -28,7 +27,7 @@ class DocumentAssertElementHasHtmlTest {
     @Test
     fun `should fail if element does not exist`() {
         // given
-        val document = Jsoup.parse("")
+        val document = JsoupUtils.parse("")
 
         // when / then
         assertThatThrownBy {
@@ -51,7 +50,7 @@ class DocumentAssertElementHasHtmlTest {
     @Test
     fun `should throw if insufficient parameters are given`() {
         // given
-        val document: Document = Jsoup.parse("")
+        val document: Document = JsoupUtils.parse("")
 
         // when / then
         assertThatThrownBy {
@@ -65,7 +64,7 @@ class DocumentAssertElementHasHtmlTest {
     @Test
     fun `should fail if element does not exist for multiple strings`() {
         // given
-        val document: Document = Jsoup.parse("")
+        val document: Document = JsoupUtils.parse("")
 
         // when / then
         assertThatThrownBy {
@@ -88,7 +87,7 @@ class DocumentAssertElementHasHtmlTest {
     @Test
     fun `should pass if element has html`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class">text<br>html</div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class">text<br>html</div>""")
 
         // when
         assertThat(document, true) {
@@ -102,7 +101,7 @@ class DocumentAssertElementHasHtmlTest {
     @Test
     fun `should pass if element has html in inner node`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"><span>text<br>html</span></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"><span>text<br>html</span></div>""")
 
         // when
         assertThat(document, true) {
@@ -116,7 +115,7 @@ class DocumentAssertElementHasHtmlTest {
     @Test
     fun `should pass if element has html in inner nodes`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"><span><b>h</b>t<strong>m</strong>l</span></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"><span><b>h</b>t<strong>m</strong>l</span></div>""")
 
         // when
         assertThat(document, true) {
@@ -130,7 +129,7 @@ class DocumentAssertElementHasHtmlTest {
     @Test
     fun `should fail if element contains substring`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class">text<br>html</div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class">text<br>html</div>""")
 
         // when / then
         assertThatThrownBy {
@@ -156,7 +155,7 @@ class DocumentAssertElementHasHtmlTest {
     @Test
     fun `should fail if element contains different html`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class">different<br>html</div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class">different<br>html</div>""")
 
         // when / then
         assertThatThrownBy {
@@ -182,7 +181,7 @@ class DocumentAssertElementHasHtmlTest {
     @Test
     fun `should pass if elements have corresponding html`() {
         // given
-        val document: Document = Jsoup.parse(
+        val document: Document = JsoupUtils.parse(
             """
             <div class="class">this<br>is</div>
             <div class="class">really<br>long</div>
@@ -202,7 +201,7 @@ class DocumentAssertElementHasHtmlTest {
     @Test
     fun `should fail if elements dont have matching html`() {
         // given
-        val document: Document = Jsoup.parse(
+        val document: Document = JsoupUtils.parse(
             """
             <div class="class">this<br>is</div>
             <div class="class">really<br>wrong</div>
@@ -234,7 +233,7 @@ class DocumentAssertElementHasHtmlTest {
     @Test
     fun `should fail if elements are missing one element`() {
         // given
-        val document: Document = Jsoup.parse(
+        val document: Document = JsoupUtils.parse(
             """
             <div class="class">this<br>is</div>
             <div class="class">really<br>long</div>
@@ -270,7 +269,7 @@ class DocumentAssertElementHasHtmlTest {
     @Test
     fun `should pass if elements have more elements than given`() {
         // given
-        val document: Document = Jsoup.parse(
+        val document: Document = JsoupUtils.parse(
             """
             <div class="class">this<br>is</div>
             <div class="class">really<br>long</div>

--- a/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementHasTextTest.kt
+++ b/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementHasTextTest.kt
@@ -6,7 +6,6 @@ import io.github.ulfs.assertj.jsoup.test.hasOneError
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.error.AssertJMultipleFailuresError
 import org.assertj.core.util.FailureMessages.actualIsNull
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import kotlin.test.Test
 
@@ -28,7 +27,7 @@ class DocumentAssertElementHasTextTest {
     @Test
     fun `should fail if element does not exist`() {
         // given
-        val document = Jsoup.parse("")
+        val document = JsoupUtils.parse("")
 
         // when / then
         assertThatThrownBy {
@@ -51,7 +50,7 @@ class DocumentAssertElementHasTextTest {
     @Test
     fun `should throw if insufficient parameters are given`() {
         // given
-        val document: Document = Jsoup.parse("")
+        val document: Document = JsoupUtils.parse("")
 
         // when / then
         assertThatThrownBy {
@@ -65,7 +64,7 @@ class DocumentAssertElementHasTextTest {
     @Test
     fun `should fail if element does not exist for multiple strings`() {
         // given
-        val document: Document = Jsoup.parse("")
+        val document: Document = JsoupUtils.parse("")
 
         // when / then
         assertThatThrownBy {
@@ -88,7 +87,7 @@ class DocumentAssertElementHasTextTest {
     @Test
     fun `should pass if element has text`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class">text</div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class">text</div>""")
 
         // when
         assertThat(document, true) {
@@ -102,7 +101,7 @@ class DocumentAssertElementHasTextTest {
     @Test
     fun `should pass if element has text in inner node`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"><span>text</span></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"><span>text</span></div>""")
 
         // when
         assertThat(document, true) {
@@ -116,7 +115,7 @@ class DocumentAssertElementHasTextTest {
     @Test
     fun `should pass if element has text in inner nodes`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"><span><b>t</b>e<strong>x</strong>t</span></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"><span><b>t</b>e<strong>x</strong>t</span></div>""")
 
         // when
         assertThat(document, true) {
@@ -130,7 +129,7 @@ class DocumentAssertElementHasTextTest {
     @Test
     fun `should fail if element contains substring`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class">text</div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class">text</div>""")
 
         // when / then
         assertThatThrownBy {
@@ -156,7 +155,7 @@ class DocumentAssertElementHasTextTest {
     @Test
     fun `should fail if element contains different text`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class">different</div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class">different</div>""")
 
         // when / then
         assertThatThrownBy {
@@ -182,7 +181,7 @@ class DocumentAssertElementHasTextTest {
     @Test
     fun `should pass if elements have corresponding text`() {
         // given
-        val document: Document = Jsoup.parse(
+        val document: Document = JsoupUtils.parse(
             """
             <div class="class">this</div>
             <div class="class">is</div>
@@ -202,7 +201,7 @@ class DocumentAssertElementHasTextTest {
     @Test
     fun `should fail if elements dont have matching text`() {
         // given
-        val document: Document = Jsoup.parse(
+        val document: Document = JsoupUtils.parse(
             """
             <div class="class">this</div>
             <div class="class">is not</div>
@@ -234,7 +233,7 @@ class DocumentAssertElementHasTextTest {
     @Test
     fun `should fail if elements are missing one element`() {
         // given
-        val document: Document = Jsoup.parse(
+        val document: Document = JsoupUtils.parse(
             """
             <div class="class">this</div>
             <div class="class">is</div>
@@ -270,7 +269,7 @@ class DocumentAssertElementHasTextTest {
     @Test
     fun `should pass if elements have more elements than given`() {
         // given
-        val document: Document = Jsoup.parse(
+        val document: Document = JsoupUtils.parse(
             """
             <div class="class">this</div>
             <div class="class">is</div>

--- a/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementMatchesHtmlTest.kt
+++ b/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementMatchesHtmlTest.kt
@@ -1,0 +1,117 @@
+package io.github.ulfs.assertj.jsoup
+
+import io.github.ulfs.assertj.jsoup.Assertions.assertThat
+import io.github.ulfs.assertj.jsoup.test.hasErrorWithMessage
+import io.github.ulfs.assertj.jsoup.test.hasOneError
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.core.util.FailureMessages.actualIsNull
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import kotlin.test.Test
+
+class DocumentAssertElementMatchesHtmlTest {
+
+    @Test
+    fun `should fail if element is null`() {
+        // given
+        val nullDocument: Document? = null
+
+        // when / then
+        assertThatThrownBy {
+            assertThat(nullDocument).elementMatchesHtml(".class", "<br>")
+        }
+            .isInstanceOf(AssertionError::class.java)
+            .hasMessage(actualIsNull())
+    }
+
+    @Test
+    fun `should fail if element does not exist`() {
+        // given
+        val document: Document = Jsoup.parse("")
+
+        // when / then
+        assertThatThrownBy {
+            assertThat(document, true) {
+                elementMatchesHtml(".class", "<br>")
+            }
+        }
+            .isInstanceOf(AssertionError::class.java)
+            .hasOneError()
+            .hasErrorWithMessage(
+                """
+                
+                Expecting element for
+                  <.class>
+                but found nothing
+                """.trimIndent()
+            )
+    }
+
+    @Test
+    fun `should pass if element html matches`() {
+        // given
+        val document: Document = Jsoup.parse("""<div class="class">text<br>html</div>""")
+
+        // when
+        assertThat(document, true) {
+            elementMatchesHtml(".class", "text<br?>html")
+        }
+
+        // then
+        // no exception is thrown
+    }
+
+    @Test
+    fun `should pass if element text matches in inner node`() {
+        // given
+        val document: Document = Jsoup.parse("""<div class="class"><span>text<br>html</span></div>""")
+
+        // when
+        assertThat(document, true) {
+            elementMatchesHtml(".class", "text<br?>html")
+        }
+
+        // then
+        // no exception is thrown
+    }
+
+    @Test
+    fun `should pass if element text matches in inner nodes`() {
+        // given
+        val document: Document = Jsoup.parse("""<div class="class"><span><b>h</b>t<strong>m</strong>l</span></div>""")
+
+        // when
+        assertThat(document, true) {
+            elementMatchesHtml(".class", "<strong>[mn]</strong>")
+        }
+
+        // then
+        // no exception is thrown
+    }
+
+    @Test
+    fun `should fail if element html does not match`() {
+        // given
+        val document: Document = Jsoup.parse("""<div class="class">text<img>html</div>""")
+
+        // when / then
+        assertThatThrownBy {
+            assertThat(document, true) {
+                elementMatchesHtml(".class", "text<br?>html")
+            }
+        }
+            .isInstanceOf(AssertionError::class.java)
+            .hasOneError()
+            .hasErrorWithMessage(
+                """
+                
+                Expecting element for
+                  <.class>
+                to match regex for html
+                  <text<br?>html>
+                but was
+                  <text<img>html>
+                """.trimIndent()
+            )
+    }
+}

--- a/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementMatchesHtmlTest.kt
+++ b/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementMatchesHtmlTest.kt
@@ -5,7 +5,6 @@ import io.github.ulfs.assertj.jsoup.test.hasErrorWithMessage
 import io.github.ulfs.assertj.jsoup.test.hasOneError
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.util.FailureMessages.actualIsNull
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import kotlin.test.Test
 
@@ -27,7 +26,7 @@ class DocumentAssertElementMatchesHtmlTest {
     @Test
     fun `should fail if element does not exist`() {
         // given
-        val document: Document = Jsoup.parse("")
+        val document: Document = JsoupUtils.parse("")
 
         // when / then
         assertThatThrownBy {
@@ -50,7 +49,7 @@ class DocumentAssertElementMatchesHtmlTest {
     @Test
     fun `should pass if element html matches`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class">text<br>html</div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class">text<br>html</div>""")
 
         // when
         assertThat(document, true) {
@@ -64,7 +63,7 @@ class DocumentAssertElementMatchesHtmlTest {
     @Test
     fun `should pass if element text matches in inner node`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"><span>text<br>html</span></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"><span>text<br>html</span></div>""")
 
         // when
         assertThat(document, true) {
@@ -78,7 +77,7 @@ class DocumentAssertElementMatchesHtmlTest {
     @Test
     fun `should pass if element text matches in inner nodes`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"><span><b>h</b>t<strong>m</strong>l</span></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"><span><b>h</b>t<strong>m</strong>l</span></div>""")
 
         // when
         assertThat(document, true) {
@@ -92,7 +91,7 @@ class DocumentAssertElementMatchesHtmlTest {
     @Test
     fun `should fail if element html does not match`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class">text<img>html</div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class">text<img>html</div>""")
 
         // when / then
         assertThatThrownBy {

--- a/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementMatchesTextTest.kt
+++ b/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementMatchesTextTest.kt
@@ -5,7 +5,6 @@ import io.github.ulfs.assertj.jsoup.test.hasErrorWithMessage
 import io.github.ulfs.assertj.jsoup.test.hasOneError
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.util.FailureMessages.actualIsNull
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import kotlin.test.Test
 
@@ -27,7 +26,7 @@ class DocumentAssertElementMatchesTextTest {
     @Test
     fun `should fail if element does not exist`() {
         // given
-        val document: Document = Jsoup.parse("")
+        val document: Document = JsoupUtils.parse("")
 
         // when / then
         assertThatThrownBy {
@@ -50,7 +49,7 @@ class DocumentAssertElementMatchesTextTest {
     @Test
     fun `should pass if element text matches`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class">text</div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class">text</div>""")
 
         // when
         assertThat(document, true) {
@@ -64,7 +63,7 @@ class DocumentAssertElementMatchesTextTest {
     @Test
     fun `should pass if element text matches in inner node`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"><span>text</span></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"><span>text</span></div>""")
 
         // when
         assertThat(document, true) {
@@ -78,7 +77,7 @@ class DocumentAssertElementMatchesTextTest {
     @Test
     fun `should pass if element text matches in inner nodes`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"><span><b>t</b>e<strong>x</strong>t</span></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"><span><b>t</b>e<strong>x</strong>t</span></div>""")
 
         // when
         assertThat(document, true) {
@@ -92,7 +91,7 @@ class DocumentAssertElementMatchesTextTest {
     @Test
     fun `should fail if element text does not match`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class">different</div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class">different</div>""")
 
         // when / then
         assertThatThrownBy {

--- a/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementNotExistsTest.kt
+++ b/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementNotExistsTest.kt
@@ -5,7 +5,6 @@ import io.github.ulfs.assertj.jsoup.test.hasErrorWithMessage
 import io.github.ulfs.assertj.jsoup.test.hasOneError
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.util.FailureMessages.actualIsNull
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import kotlin.test.Test
 
@@ -27,7 +26,7 @@ class DocumentAssertElementNotExistsTest {
     @Test
     fun `should pass if element does not exist`() {
         // given
-        val document: Document = Jsoup.parse("")
+        val document: Document = JsoupUtils.parse("")
 
         // when
         assertThat(document, true) {
@@ -41,7 +40,7 @@ class DocumentAssertElementNotExistsTest {
     @Test
     fun `should fail if element exists`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"/>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"/>""")
 
         // when / then
         assertThatThrownBy {

--- a/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementNotHasClassTest.kt
+++ b/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentAssertElementNotHasClassTest.kt
@@ -6,7 +6,6 @@ import io.github.ulfs.assertj.jsoup.test.hasOneError
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.error.AssertJMultipleFailuresError
 import org.assertj.core.util.FailureMessages.actualIsNull
-import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import kotlin.test.Test
 
@@ -28,7 +27,7 @@ class DocumentAssertElementNotHasClassTest {
     @Test
     fun `should fail if element does not exist`() {
         // given
-        val document: Document = Jsoup.parse("")
+        val document: Document = JsoupUtils.parse("")
 
         // when / then
         assertThatThrownBy {
@@ -51,7 +50,7 @@ class DocumentAssertElementNotHasClassTest {
     @Test
     fun `should pass if element does not have class attribute`() {
         // given
-        val document: Document = Jsoup.parse("""<div id="id">""")
+        val document: Document = JsoupUtils.parse("""<div id="id">""")
 
         // when / then
         assertThat(document, true) {
@@ -65,7 +64,7 @@ class DocumentAssertElementNotHasClassTest {
     @Test
     fun `should fail if element has class`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class content">text</div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class content">text</div>""")
 
         // when
         assertThatThrownBy {
@@ -96,7 +95,7 @@ class DocumentAssertElementNotHasClassTest {
     @Test
     fun `should pass if only inner element has class`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class"><span class="content">text</span></div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class"><span class="content">text</span></div>""")
 
         // when
         assertThat(document, true) {
@@ -110,7 +109,7 @@ class DocumentAssertElementNotHasClassTest {
     @Test
     fun `should pass if element does not have class`() {
         // given
-        val document: Document = Jsoup.parse("""<div class="class cont">text</div>""")
+        val document: Document = JsoupUtils.parse("""<div class="class cont">text</div>""")
 
         // when / then
         assertThat(document, true) {

--- a/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentSoftAssertionsTest.kt
+++ b/src/test/kotlin/io/github/ulfs/assertj/jsoup/DocumentSoftAssertionsTest.kt
@@ -27,7 +27,7 @@ class DocumentSoftAssertionsTest {
         val assertions = DocumentSoftAssertions(true)
 
         // when
-        assertions.assertThat(Jsoup.parse(""))
+        assertions.assertThat(JsoupUtils.parse(""))
             .elementExists(".class")
         // then
         // no exception is thrown
@@ -46,7 +46,7 @@ class DocumentSoftAssertionsTest {
 
         // when / then
         assertThatThrownBy {
-            assertions.assertThat(Jsoup.parse(""))
+            assertions.assertThat(JsoupUtils.parse(""))
                 .elementExists(".class")
         }
             .isInstanceOf(AssertionError::class.java)

--- a/src/test/kotlin/io/github/ulfs/assertj/jsoup/NodeAssertionsSpecTest.kt
+++ b/src/test/kotlin/io/github/ulfs/assertj/jsoup/NodeAssertionsSpecTest.kt
@@ -62,6 +62,90 @@ class NodeAssertionsSpecTest {
     }
 
     @Test
+    fun `should call elementContainsHtml`() {
+        // given
+        every { softAssertions.assertThat(any<Document>()).elementContainsHtml(any(), any()) } returns dummySoftAssertions()
+
+        val spec = spec()
+
+        // when
+        spec.containsHtml("html")
+
+        // then
+        verify { softAssertions.assertThat(any<Document>()).elementContainsHtml("selector", "html") }
+    }
+
+    @Test
+    fun `should call elementHasHtml`() {
+        // given
+        every { softAssertions.assertThat(any<Document>()).elementHasHtml(any(), any()) } returns dummySoftAssertions()
+
+        val spec = spec()
+
+        // when
+        spec.hasHtml("html")
+
+        // then
+        verify { softAssertions.assertThat(any<Document>()).elementHasHtml("selector", "html") }
+    }
+
+    @Test
+    fun `should call elementHasHtml with multiple arguments`() {
+        // given
+        every { softAssertions.assertThat(any<Document>()).elementHasHtml(any(), any(), any()) } returns dummySoftAssertions()
+
+        val spec = spec()
+
+        // when
+        spec.hasHtml("html1", "html2")
+
+        // then
+        verify { softAssertions.assertThat(any<Document>()).elementHasHtml("selector", "html1", "html2") }
+    }
+
+    @Test
+    fun `should call elementHasHtml with object argument`() {
+        // given
+        every { softAssertions.assertThat(any<Document>()).elementHasHtml(any(), any()) } returns dummySoftAssertions()
+
+        val spec = spec()
+
+        // when
+        spec.hasHtml(42)
+
+        // then
+        verify { softAssertions.assertThat(any<Document>()).elementHasHtml("selector", "42") }
+    }
+
+    @Test
+    fun `should call elementHasHtml with null argument`() {
+        // given
+        every { softAssertions.assertThat(any<Document>()).elementHasHtml(any(), any()) } returns dummySoftAssertions()
+
+        val spec = spec()
+
+        // when
+        spec.hasHtml(null)
+
+        // then
+        verify { softAssertions.assertThat(any<Document>()).elementHasHtml("selector", "") }
+    }
+
+    @Test
+    fun `should call elementHasHtml with argument returning null for toString`() {
+        // given
+        every { softAssertions.assertThat(any<Document>()).elementHasHtml(any(), any()) } returns dummySoftAssertions()
+
+        val spec = spec()
+
+        // when
+        spec.hasHtml(ClassWithNullToString())
+
+        // then
+        verify { softAssertions.assertThat(any<Document>()).elementHasHtml("selector", "") }
+    }
+
+    @Test
     fun `should call elementContainsText`() {
         // given
         every { softAssertions.assertThat(any<Document>()).elementContainsText(any(), any()) } returns dummySoftAssertions()


### PR DESCRIPTION
- adds `elementHasHtml` & DSL `hasHtml` for exact matches
- adds `elementContainsHtml` & DSL `containsHtml` to check if it includes the content
- adds `elementMatchesHtml` to allow regular expressions

Keep in mind that the assertions are based on the parsed `Document` representation and might differ from the original raw html content. Additionally, the document is subject to the Document's/JSoup's output settings.

In order to match on (more or less) raw content (incl. spaces, newlines etc.), you need to modify the Document's output settings. See https://jsoup.org/apidocs/org/jsoup/nodes/Document.html#outputSettings()